### PR TITLE
FUM-4116: replace aws_region.current.name with aws_region.current.region

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ as described in the `.pre-commit-config.yaml` file
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 

--- a/ecs_service.tf
+++ b/ecs_service.tf
@@ -36,7 +36,7 @@ resource "aws_ecs_task_definition" "this" {
         logDriver = "awslogs"
         options = {
           awslogs-group         = aws_cloudwatch_log_group.this.name
-          awslogs-region        = data.aws_region.current.name
+          awslogs-region        = data.aws_region.current.region
           awslogs-stream-prefix = "ecs"
         }
       }

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 6.0"
     }
   }
 }


### PR DESCRIPTION
The `name` attribute of the `aws_region` data source is deprecated in favor of `region` as of AWS provider v6.0.0. Bump the minimum provider version to >= 6.0 accordingly. 

To be able to upgrade https://github.com/tx-pts-dai/ness-nebula-app this change is needed. 

